### PR TITLE
Add shaded Gson 2.13.1 library for JSON support

### DIFF
--- a/gw-gson/pom.xml
+++ b/gw-gson/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>gw-gson</artifactId>
+  <version>${gson.version}</version>
+  <packaging>jar</packaging>
+
+  <parent>
+    <groupId>org.gosu-lang.gosu.managed</groupId>
+    <artifactId>parent</artifactId>
+    <version>1.0</version>
+    <relativePath>../parent</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>${gson.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>com.google.gson</pattern>
+                  <shadedPattern>gw.internal.ext.com.google.gson</shadedPattern>
+                </relocation>
+              </relocations>
+              <createSourcesJar>true</createSourcesJar>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/gw-gson/src/main/java/gw/Dummy.java
+++ b/gw-gson/src/main/java/gw/Dummy.java
@@ -1,0 +1,6 @@
+package gw;
+
+/**
+ A Dummy class
+ */
+public class Dummy {}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -39,6 +39,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <asm.version>9.7</asm.version>
     <common-cli.version>1.5.0</common-cli.version>
+    <gson.version>2.13.1</gson.version>
     <jcommander.version>1.78</jcommander.version>
     <xercesImpl.Version>2.12.2</xercesImpl.Version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <module>gw-asm-debug-all</module>
     <module>gw-asm-util</module>
     <module>gw-commons-cli</module>
+    <module>gw-gson</module>
     <module>gw-jcommander</module>
     <module>gw-xercesImpl</module>
   </modules>


### PR DESCRIPTION
- Add gw-gson module with shaded Gson 2.13.1
- Relocates com.google.gson to gw.internal.ext.com.google.gson
- Uses maven-shade-plugin 3.5.1 for compatibility with latest Gson
- Follows existing pattern for shaded third-party libraries
- Will be used for incremental compilation dependency tracking

🤖 Generated with Claude Code